### PR TITLE
feat: allow specifying vite/vitest configuration options

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,22 @@ Setting up the Nitro test environment for Vitest is as simple as creating a new 
 ```ts
 import { defineConfig } from 'nitro-test-utils/config'
 
-export default defineConfig({})
+export default defineConfig({
+  /*
+   * You may specify configuration options in here.
+   *
+   * The following configurations cannot be overridden:
+   * - `test.poolOptions.forks.isolate`: always set to `false`
+   * - `test.poolOptions.forks.singleFork`: always set to `true`
+   *
+   * The following options have special behaviors:
+   * - `test.forceRerunTriggers`:
+   *   - If unspecified, includes `vitest` defaults
+   *   - Always include `nitro` output
+   * - `test.globalSetup`:
+   *   - Always include a script that starts `nitro` server and configures `.env.test`
+   */
+})
 ```
 
 > [!TIP]

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ export default defineConfig({
   /*
    * You may specify configuration options in here.
    *
-   * The following configurations cannot be overridden:
+   * The following options cannot be overridden:
    * - `test.poolOptions.forks.isolate`: always set to `false`
    * - `test.poolOptions.forks.singleFork`: always set to `true`
    *

--- a/src/config.ts
+++ b/src/config.ts
@@ -28,20 +28,31 @@ export function defineConfig(config: ViteUserConfig = {}): ViteUserConfig {
       mode: 'development',
     },
   })
+  const { test } = config
 
   return defineVitestConfig({
+    ...config,
     test: {
+      ...test,
       poolOptions: {
+        ...test?.poolOptions,
         forks: {
+          ...test?.poolOptions?.forks,
           // Disabling isolation improves performance in this case
           isolate: false,
           singleFork: true,
         },
       },
       forceRerunTriggers: [
-        // Vitest defaults
-        '**/package.json/**',
-        '**/{vitest,vite}.config.*/**',
+        ...(
+          test?.forceRerunTriggers
+            ? test?.forceRerunTriggers
+            : [
+              // Vitest defaults
+                '**/package.json/**',
+                '**/{vitest,vite}.config.*/**',
+              ]
+        ),
         // Re-run tests when Nitro is rebuilt
         join(
           _config.nitro?.rootDir || '',
@@ -51,6 +62,7 @@ export function defineConfig(config: ViteUserConfig = {}): ViteUserConfig {
         ),
       ],
       globalSetup: [
+        ...(test?.globalSetup ? test?.globalSetup : []),
         join(currentDir, 'setup.mjs'),
       ],
       // @ts-expect-error: Append Nitro config to access in global setup file

--- a/test/fail.test.ts
+++ b/test/fail.test.ts
@@ -1,0 +1,3 @@
+import { expect, it } from 'vitest'
+
+it('fails', () => expect.fail('This should never execute.'))

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,6 +2,9 @@
 import { defineConfig } from './dist/config.mjs'
 
 export default defineConfig({
+  test: {
+    include: ['test/routes.test.ts'],
+  },
   nitro: {
     rootDir: 'test/fixture',
   },


### PR DESCRIPTION
WHAT?

Allow users to specify `vite` and `vitest` configuration while ensuring the necessary configuration by `nitro-test-utils` is maintained.

WHY?

The current version of the package does not allow users to specify any configuration.

There are valid use cases for users to specify one like packages with a mixture of unit and integ/e2e tests where the users may want to exclude the unit tests `nitro-test-utils`'s while running integ/e2t tests. The workaround without this ability is to exclude all the unit tests with the following which relies on an internal implementation detail:

```ts
import { describe, inject } from 'vitest'

describe.skipIf(inject('nitroServerUrl'))("unit tests", () => {
  // ...
});
```

HOW?

`pnpm prepare && pnpm test -- --run && pnpm lint && pnpm test:types`